### PR TITLE
fix(producer): Avoid NullPointerException due to missing schema.registry.url

### DIFF
--- a/pom-maven-central.xml
+++ b/pom-maven-central.xml
@@ -7,7 +7,7 @@
 
   <artifactId>kloadgen</artifactId>
 
-  <version>5.4.3</version>
+  <version>5.4.4</version>
 
   <name>KLoadGen</name>
   <description>Load Generation Jmeter plugin for Kafka Cluster. Supporting AVRO, JSON Schema and Protobuf schema types. Generate Artificial

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <artifactId>kloadgen</artifactId>
 
-  <version>5.4.3</version>
+  <version>5.4.4</version>
 
   <name>KLoadGen</name>
   <description>Load Generation Jmeter plugin for Kafka Cluster. Supporting AVRO, JSON Schema and Protobuf schema types. Generate Artificial

--- a/src/main/java/com/sngular/kloadgen/sampler/SamplerUtil.java
+++ b/src/main/java/com/sngular/kloadgen/sampler/SamplerUtil.java
@@ -92,6 +92,7 @@ public final class SamplerUtil {
     defaultParameters.addArgument(SslConfigs.SSL_PROVIDER_CONFIG, "");
     defaultParameters.addArgument(SslConfigs.SSL_PROTOCOL_CONFIG, SslConfigs.DEFAULT_SSL_PROTOCOL);
     defaultParameters.addArgument(SchemaRegistryKeyHelper.ENABLE_AUTO_SCHEMA_REGISTRATION_CONFIG, ProducerKeysHelper.ENABLE_AUTO_SCHEMA_REGISTRATION_CONFIG_DEFAULT);
+    defaultParameters.addArgument(SchemaRegistryKeyHelper.SCHEMA_REGISTRY_URL, "");
 
     return defaultParameters;
   }
@@ -134,7 +135,10 @@ public final class SamplerUtil {
       props.put(SchemaResolverConfig.REGISTRY_URL, context.getJMeterVariables().get(SchemaResolverConfig.REGISTRY_URL));
     } else {
       props.put(SchemaRegistryKeyHelper.ENABLE_AUTO_SCHEMA_REGISTRATION_CONFIG, enableSchemaRegistrationValue);
-      props.put(SchemaRegistryKeyHelper.SCHEMA_REGISTRY_URL, context.getJMeterVariables().get(SchemaRegistryKeyHelper.SCHEMA_REGISTRY_URL));
+      String schemaRegistryURL = context.getJMeterVariables().get(SchemaRegistryKeyHelper.SCHEMA_REGISTRY_URL);
+      if (StringUtils.isNotBlank(schemaRegistryURL)) {
+        props.put(SchemaRegistryKeyHelper.SCHEMA_REGISTRY_URL, schemaRegistryURL);
+      }
     }
 
     final Iterator<String> parameters = context.getParameterNamesIterator();


### PR DESCRIPTION
When using a Producer with Simple Value Config, a NullPointerException is thrown.

This is due to `SamplerUtil.configureValueGenerator` throwing its own NPE on line 137, because `schema.registry.url` is null.
Worse, it is not possible to set a value: upon saving, the value is erased.

The JMeter output:
```
2023-04-04 14:35:39,502 ERROR o.a.j.t.JMeterThread: Error while processing sampler: 'Kafka producer -  Test instance XXX'.
java.lang.NullPointerException: Cannot invoke "com.sngular.kloadgen.loadgen.BaseLoadGenerator.nextMessage()" because "this.generator" is null
	at com.sngular.kloadgen.sampler.KafkaProducerSampler.runTest(KafkaProducerSampler.java:137) ~[kloadgen-5.4.3.jar:?]
	at org.apache.jmeter.protocol.java.sampler.JavaSampler.sample(JavaSampler.java:197) ~[ApacheJMeter_java.jar:5.5]
	at org.apache.jmeter.threads.JMeterThread.doSampling(JMeterThread.java:651) ~[ApacheJMeter_core.jar:5.5]
	at org.apache.jmeter.threads.JMeterThread.executeSamplePackage(JMeterThread.java:570) ~[ApacheJMeter_core.jar:5.5]
	at org.apache.jmeter.threads.JMeterThread.processSampler(JMeterThread.java:501) ~[ApacheJMeter_core.jar:5.5]
	at org.apache.jmeter.threads.JMeterThread.run(JMeterThread.java:268) ~[ApacheJMeter_core.jar:5.5]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```