### PR TITLE
381 issue schema registry url field not recognized when running kafka producer with apicurio

### DIFF
--- a/pom-maven-central.xml
+++ b/pom-maven-central.xml
@@ -7,7 +7,7 @@
 
   <artifactId>kloadgen</artifactId>
 
-  <version>5.6.2</version>
+  <version>5.6.3</version>
 
   <name>KLoadGen</name>
   <description>Load Generation Jmeter plugin for Kafka Cluster. Supporting AVRO, JSON Schema and Protobuf schema types. Generate Artificial

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <artifactId>kloadgen</artifactId>
 
-  <version>5.6.2</version>
+  <version>5.6.3</version>
 
   <name>KLoadGen</name>
   <description>Load Generation Jmeter plugin for Kafka Cluster. Supporting AVRO, JSON Schema and Protobuf schema types. Generate Artificial

--- a/src/main/java/com/sngular/kloadgen/sampler/SamplerUtil.java
+++ b/src/main/java/com/sngular/kloadgen/sampler/SamplerUtil.java
@@ -92,8 +92,6 @@ public final class SamplerUtil {
     defaultParameters.addArgument(SslConfigs.SSL_PROVIDER_CONFIG, "");
     defaultParameters.addArgument(SslConfigs.SSL_PROTOCOL_CONFIG, SslConfigs.DEFAULT_SSL_PROTOCOL);
     defaultParameters.addArgument(SchemaRegistryKeyHelper.ENABLE_AUTO_SCHEMA_REGISTRATION_CONFIG, ProducerKeysHelper.ENABLE_AUTO_SCHEMA_REGISTRATION_CONFIG_DEFAULT);
-    defaultParameters.addArgument(SchemaRegistryKeyHelper.SCHEMA_REGISTRY_URL, "");
-
     return defaultParameters;
   }
 

--- a/src/main/java/com/sngular/kloadgen/sampler/SamplerUtil.java
+++ b/src/main/java/com/sngular/kloadgen/sampler/SamplerUtil.java
@@ -133,9 +133,10 @@ public final class SamplerUtil {
     if (SchemaRegistryKeyHelper.SCHEMA_REGISTRY_APICURIO.equalsIgnoreCase(schemaRegistryNameValue)) {
       props.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, enableSchemaRegistrationValue);
       props.put(SchemaResolverConfig.REGISTRY_URL, context.getJMeterVariables().get(SchemaResolverConfig.REGISTRY_URL));
+      props.put(SchemaRegistryKeyHelper.SCHEMA_REGISTRY_URL, context.getJMeterVariables().get(SchemaResolverConfig.REGISTRY_URL));
     } else {
       props.put(SchemaRegistryKeyHelper.ENABLE_AUTO_SCHEMA_REGISTRATION_CONFIG, enableSchemaRegistrationValue);
-      String schemaRegistryURL = context.getJMeterVariables().get(SchemaRegistryKeyHelper.SCHEMA_REGISTRY_URL);
+      final String schemaRegistryURL = context.getJMeterVariables().get(SchemaRegistryKeyHelper.SCHEMA_REGISTRY_URL);
       if (StringUtils.isNotBlank(schemaRegistryURL)) {
         props.put(SchemaRegistryKeyHelper.SCHEMA_REGISTRY_URL, schemaRegistryURL);
       }


### PR DESCRIPTION
Why: This PR its to resolve a bug related with Apicurio Schema Registry didn't connect with correct filled properties, the problem was related about missing statement with the Producer Properties. In other way a little refactor about a unused property related with the KafkaProducerSampler
